### PR TITLE
Show login error on same page

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -216,12 +216,12 @@ func (a *App) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		var hash string
 		var username string
 		err := a.DB.QueryRow(`SELECT id, username, password_hash FROM users WHERE email=?`, email).Scan(&id, &username, &hash)
-		if err != nil {
-			http.Error(w, "invalid credentials", http.StatusUnauthorized)
-			return
-		}
-		if bcrypt.CompareHashAndPassword([]byte(hash), []byte(pass)) != nil {
-			http.Error(w, "invalid credentials", http.StatusUnauthorized)
+		if err != nil || bcrypt.CompareHashAndPassword([]byte(hash), []byte(pass)) != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			a.render(w, "login.html", map[string]any{
+				"View":  "login",
+				"Error": "invalid credentials",
+			})
 			return
 		}
 		sid := uuid.NewString()

--- a/internal/web/templates/login.html
+++ b/internal/web/templates/login.html
@@ -3,6 +3,9 @@
 {{define "title"}}Login{{end}}
 {{define "content"}}
 <div class="card" style="max-width:480px; margin:0 auto;">
+  {{if .Error}}
+  <p style="color:#f87171">{{.Error}}</p>
+  {{end}}
   <form method="post" action="/login">
     <label>Email</label>
     <input type="email" name="email" required>


### PR DESCRIPTION
## Summary
- render login page with inline invalid credentials error
- display error message within login form

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6899ff9a4e9883339bea9cf2857493d8